### PR TITLE
fix: Fix SpotDiagramsGrid for all screen sizes

### DIFF
--- a/demo/SpotDiagramsGridSingleWavelength.tsx
+++ b/demo/SpotDiagramsGridSingleWavelength.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { SpotDiagramsGrid } from '../src';
+import { RayTraceResults } from '../src';
+import data from './demo.json' with { type: 'json' };
+
+const rayTraceResults: RayTraceResults = data;
+const filteredResults = rayTraceResults.filter(
+  (result) => result.wavelengthId === 0 && result.fieldId === 0,
+);
+
+const props = {
+  rayTraceResults: filteredResults,
+  wavelengths: [
+    { value: 0.4861, units: 'µm' },
+  ],
+  fieldSpecs: [
+    { value: 0.0, units: 'deg', type: 'angle' } as const,
+  ],
+};
+
+ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(
+  <React.StrictMode>
+    <SpotDiagramsGrid {...props} />
+  </React.StrictMode>,
+);

--- a/demo/SpotDiagramsGridSingleWavelength.tsx
+++ b/demo/SpotDiagramsGridSingleWavelength.tsx
@@ -11,12 +11,8 @@ const filteredResults = rayTraceResults.filter(
 
 const props = {
   rayTraceResults: filteredResults,
-  wavelengths: [
-    { value: 0.4861, units: 'µm' },
-  ],
-  fieldSpecs: [
-    { value: 0.0, units: 'deg', type: 'angle' } as const,
-  ],
+  wavelengths: [{ value: 0.4861, units: 'µm' }],
+  fieldSpecs: [{ value: 0.0, units: 'deg', type: 'angle' } as const],
 };
 
 ReactDOM.createRoot(document.getElementById('app') as HTMLElement).render(

--- a/src/components/SpotDiagram/SpotDiagram.tsx
+++ b/src/components/SpotDiagram/SpotDiagram.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
+import { SPOT_DIAGRAMS_GRID_CELL_MAX_WIDTH } from '../../constants';
 import Axis from '../Axis';
 import { BoundingBox, RayTraceResult, SpotDiagramOptions } from '../../types';
 import { dataBox, fontSize, padBox, titlePosition } from '../../data/layout';
 
 const SVGContainer = styled.div`
-  max-width: 100%;
+  max-width: ${SPOT_DIAGRAMS_GRID_CELL_MAX_WIDTH};
 `;
 
 const StyledTitle = styled.text.attrs((props) => ({
@@ -49,7 +50,6 @@ const SpotDiagram = (props: SpotDiagramProps) => {
     <SVGContainer>
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        width="100%"
         viewBox={`${xMin} ${yMin} ${width} ${height}`}
         preserveAspectRatio="xMidYMid meet"
       >

--- a/src/components/SpotDiagramsGrid/SpotDiagramsGrid.tsx
+++ b/src/components/SpotDiagramsGrid/SpotDiagramsGrid.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import SpotDiagram from '../SpotDiagram';
+import { SPOT_DIAGRAMS_GRID_CELL_MAX_WIDTH } from '../../constants';
 import {
   FieldSpec,
   RayTraceResult,
@@ -18,9 +19,13 @@ import { sortSystemSpecsIndexes } from '../../data/specs';
 
 const GridContainer = styled.div`
   display: grid;
-  grid-template-columns: repeat(var(--max-columns), 1fr);
-  align-items: center;
-  width: 100%;
+  grid-template-columns: repeat(
+    var(--max-columns),
+    minmax(0, ${SPOT_DIAGRAMS_GRID_CELL_MAX_WIDTH})
+  );
+  justify-content: center;
+  margin-left: auto;
+  margin-right: auto;
 `;
 
 interface SpotDiagramsGridProps {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const SPOT_DIAGRAMS_GRID_CELL_MAX_WIDTH = '480px';


### PR DESCRIPTION
The SpotDiagramsGrid how uses a maximum size (in pixels) for all its cells. This means that grids with only one item no longer fill the entire screen on desktop, but still look good on mobile.